### PR TITLE
all: fix JSON typos

### DIFF
--- a/rubiconproject/example-request-app-android-2.json
+++ b/rubiconproject/example-request-app-android-2.json
@@ -45,7 +45,7 @@
             "country": "CAN",
             "region": "ON",
             "lat": 13.519004709972312,
-            "lon": -44,23060478189526,
+            "lon": -44.23060478189526,
             "type": 2,
             "ext": {
                 "latlonconsent": 1

--- a/spotxchange/example-video-request-multiple_impr.md
+++ b/spotxchange/example-video-request-multiple_impr.md
@@ -143,7 +143,7 @@ object. A few notes about specific fields in the example:
     },
     {
       "id": "3",
-      "bidfloor": 2.00
+      "bidfloor": 2.00,
       "video": {
         "mimes": [
           "video/x-flv",


### PR DESCRIPTION
* rubiconproject:
Fixes "lon" value to have a decimal point instead of comma.
### Before
<img width="1053" alt="screen shot 2017-01-02 at 5 05 38 am" src="https://cloud.githubusercontent.com/assets/4898263/21588964/9aea9104-d0a9-11e6-9343-6f15ca40330a.png">


* spotxchange:
Fixes JSON value separator by adding a comma.
### Before
<img width="1107" alt="screen shot 2017-01-02 at 5 03 57 am" src="https://cloud.githubusercontent.com/assets/4898263/21588965/9eeb3f06-d0a9-11e6-933a-17c6cade5a8a.png">
